### PR TITLE
Add/enhance timl.core vars

### DIFF
--- a/autoload/timl/core.tim
+++ b/autoload/timl/core.tim
@@ -62,14 +62,47 @@
   ([x] x)
   ([x & xs] `(let [and# ~x] (if and# (and ~@xs) and#))))
 
-(defn map [f coll]
-  (lazy-seq
-    (when-let [s (seq coll)]
-      (if (can? s chunk-first)
-        (concat
-          (#*timl#coll#mutating_map f (chunk-first s))
-          (map f (chunk-rest s)))
-        (cons (f (first s)) (map f (rest s)))))))
+(defn map 
+  ([f coll]
+   (lazy-seq
+     (when-let [s (seq coll)]
+               (if (can? s chunk-first)
+                 (concat
+                   (#*timl#coll#mutating_map f (chunk-first s))
+                   (map f (chunk-rest s)))
+                 (cons (f (first s)) (map f (rest s)))))))
+  ([f c1 c2]
+   (lazy-seq
+    (let [s1 (seq c1) s2 (seq c2)]
+      (when (and s1 s2)
+        (cons (f (first s1) (first s2))
+              (map f (rest s1) (rest s2)))))))
+  ([f c1 c2 c3]
+   (lazy-seq
+    (let [s1 (seq c1) s2 (seq c2) s3 (seq c3)]
+      (when (and  s1 s2 s3)
+        (cons (f (first s1) (first s2) (first s3))
+              (map f (rest s1) (rest s2) (rest s3)))))))
+  ([f c1 c2 c3 & colls]
+   (let [step (fn step [cs]
+                 (lazy-seq
+                  (let [ss (map seq cs)]
+                    (when (every? identity ss)
+                      (cons (map first ss) (step (map rest ss)))))))]
+     (map #(apply f %) (step (conj colls c3 c2 c1))))))
+
+
+(defn mapv
+  ([f coll]
+     (-> (reduce (fn [v o] (conj! v (f o))) (transient []) coll)
+         persistent!))
+  ([f c1 c2]
+     (into [] (map f c1 c2)))
+  ([f c1 c2 c3]
+     (into [] (map f c1 c2 c3)))
+  ([f c1 c2 c3 & colls]
+     (into [] (apply map f c1 c2 c3 colls))))
+
 
 (defn dorun
   ([coll]

--- a/autoload/timl/core_basics.tim
+++ b/autoload/timl/core_basics.tim
@@ -31,3 +31,10 @@
   ([k x y] (if (> (k x) (k y)) x y))
   ([k x y & more]
    (reduce #(max-key k %1 %2) (max-key k x y) more)))
+
+(defn min-key
+  ([k x] x)
+  ([k x y] (if (< (k x) (k y)) x y))
+  ([k x y & more]
+   (reduce #(min-key k %1 %2) (min-key k x y) more)))
+

--- a/autoload/timl/core_coll.tim
+++ b/autoload/timl/core_coll.tim
@@ -28,3 +28,16 @@
   [& maps]
   (when (some identity maps)
     (reduce #(conj (or %1 {}) %2) maps)))
+
+(defn merge-with
+  [f & maps]
+  (when (some identity maps)
+    (let [merge-entry (fn [m e]
+      (let [k (key e) v (val e)]
+        (if (contains? m k)
+          (assoc m k (f (get m k) v))
+          (assoc m k v))))
+          merge2 (fn [m1 m2]
+       (reduce merge-entry (or m1 {}) (seq m2)))]
+      (reduce merge2 maps))))
+

--- a/autoload/timl/core_macros.tim
+++ b/autoload/timl/core_macros.tim
@@ -49,3 +49,84 @@
      result#))
 
 (defmacro comment [& body])
+
+(defmacro doseq
+  [seq-exprs & body]
+  #_(assert-args
+     (vector? seq-exprs) "a vector for its binding"
+     (even? (count seq-exprs)) "an even number of forms in binding vector")
+  (let [step (fn step [recform exprs]
+               (if-not exprs
+                 [true `(do ~@body)]
+                 (let [k (first exprs)
+                       v (second exprs)]
+                   (if (keyword? k)
+                     (let [steppair (step recform (nnext exprs))
+                           needrec (steppair 0)
+                           subform (steppair 1)]
+                       (cond
+                         (= k :let) [needrec `(let ~v ~subform)]
+                         (= k :while) [false `(when ~v
+                                                ~subform
+                                                ~@(when needrec [recform]))]
+                         (= k :when) [false `(if ~v
+                                               (do
+                                                 ~subform
+                                                 ~@(when needrec [recform]))
+                                               ~recform)]))
+                     (let [seq- (gensym "seq_")
+                           chunk- (gensym "chunk_")
+                           count- (gensym "count_")
+                           i- (gensym "i_")
+                           recform `(recur (next ~seq-) nil 0 0)
+                           steppair (step recform (nnext exprs))
+                           needrec (steppair 0)
+                           subform (steppair 1)
+                           recform-chunk 
+                             `(recur ~seq- ~chunk- ~count- (inc ~i-)) ;unchecked-inc in Clojure
+                           steppair-chunk (step recform-chunk (nnext exprs))
+                           subform-chunk (steppair-chunk 1)]
+                       [true
+                        `(loop [~seq- (seq ~v), ~chunk- nil,
+                                ~count- 0, ~i- 0]
+                           (if (< ~i- ~count-)
+                             (let [~k (nth ~chunk- ~i-)]
+                               ~subform-chunk
+                               ~@(when needrec [recform-chunk]))
+                             (when-let [~seq- (seq ~seq-)]
+                               (if (chunked-seq? ~seq-)
+                                 (let [c# (chunk-first ~seq-)]
+                                   (recur (chunk-rest ~seq-) c#
+                                          (int (count c#)) (int 0)))
+                                 (let [~k (first ~seq-)]
+                                   ~subform
+                                   ~@(when needrec [recform]))))))])))))]
+    (nth (step nil (seq seq-exprs)) 1)))
+
+(defmacro dotimes
+  [bindings & body]
+  #_(assert-args
+     (vector? bindings) "a vector for its binding"
+     (= 2 (count bindings)) "exactly 2 forms in binding vector")
+  (let [i (first bindings)
+        n (second bindings)]
+    `(let [n# (int ~n)] ; Clojure uses (long ~n)
+       (loop [~i 0]
+         (when (< ~i n#)
+           ~@body
+           (recur (inc ~i))))))) ;Clojure uses (unchecked-inc ~i)
+
+(defmacro when-first
+  [bindings & body]
+  #_(assert-args
+     (vector? bindings) "a vector for its binding"
+     (= 2 (count bindings)) "exactly 2 forms in binding vector")
+  (let [[x xs] bindings]
+    `(when-let [xs# (seq ~xs)]
+       (let [~x (first xs#)]
+           ~@body))))
+
+(defmacro lazy-cat
+  [& colls]
+  `(concat ~@(map #(list `lazy-seq %) colls)))
+

--- a/autoload/timl/core_seq.tim
+++ b/autoload/timl/core_seq.tim
@@ -66,3 +66,76 @@
   [pred coll]
   (when (seq coll)
     (or (pred (first coll)) (recur pred (next coll)))))
+
+(defn mapcat
+  [f & colls]
+  (apply concat (apply map f colls)))
+
+(defn take-while
+  [pred coll]
+  (lazy-seq
+   (when-let [s (seq coll)]
+       (when (pred (first s))
+         (cons (first s) (take-while pred (rest s)))))))
+
+(defn drop-last
+  ([s] (drop-last 1 s))
+  ([n s] (map (fn [x _] x) s (drop n s))))
+
+(defn take-last
+  [n coll]
+  (loop [s (seq coll), lead (seq (drop n coll))]
+    (if lead
+      (recur (next s) (next lead))
+      s)))
+
+(defn drop-while
+  [pred coll]
+  (let [step (fn [pred coll]
+               (let [s (seq coll)]
+                 (if (and s (pred (first s)))
+                   (recur pred (rest s))
+                   s)))]
+    (lazy-seq (step pred coll))))
+
+(defn cycle
+  [coll] (lazy-seq 
+          (when-let [s (seq coll)] 
+              (concat s (cycle s)))))
+
+(defn split-at
+  [n coll]
+    [(take n coll) (drop n coll)])
+
+(defn split-with
+  [pred coll]
+    [(take-while pred coll) (drop-while pred coll)])
+
+(defn nthrest
+  [coll n]
+    (loop [n n xs coll]
+      (if (and (pos? n) (seq xs))
+        (recur (dec n) (rest xs))
+        xs)))
+
+(defn take-nth
+  [n coll]
+    (lazy-seq
+     (when-let [s (seq coll)]
+       (cons (first s) (take-nth n (drop n s))))))
+
+(defn interleave
+  ([] ())
+  ([c1] (lazy-seq c1))
+  ([c1 c2]
+     (lazy-seq
+      (let [s1 (seq c1) s2 (seq c2)]
+        (when (and s1 s2)
+          (cons (first s1) (cons (first s2) 
+                                 (interleave (rest s1) (rest s2))))))))
+  ([c1 c2 & colls] 
+     (lazy-seq 
+      (let [ss (map seq (conj colls c2 c1))]
+        (when (every? identity ss)
+          (concat (map first ss) (apply interleave (map rest ss))))))))
+


### PR DESCRIPTION
# Notes
- changed `unchecked-inc` to `inc`
- changed `long` to `int`
# Enhance
- multi-arity map
# Add
- mapv
- min-key
- merge-with
- doseq
- dotimes
- when-first
- lazy-cat
- mapcat
- take-while
- drop-last
- take-last
- drop-while
- cycle
- split-at
- split-with
- nthrest
- take-nth
- interleave
