### PR TITLE
Fix lencompare

### DIFF
--- a/autoload/timl/interactive.vim
+++ b/autoload/timl/interactive.vim
@@ -10,7 +10,7 @@ function! s:function(name) abort
 endfunction
 
 function! s:lencompare(a, b) abort
-  return len(a:b) - len(a:b)
+  return len(a:a) - len(a:b)
 endfunction
 
 function! timl#interactive#ns_for_file(file) abort


### PR DESCRIPTION
My understanding is that this is finding the most specific path to use.
There was a typo in lencompare that was causing it to return 0 all the time.
